### PR TITLE
降水量の傾向取得APIのガワだけ作成、レスポンスはモックです

### DIFF
--- a/getRainFallTrend.py
+++ b/getRainFallTrend.py
@@ -4,13 +4,12 @@ import boto3
 
 client = boto3.client('s3')
 
-def lambda_handler(event, context):
-    bucket = 'test-uodu-s3'
-    key = 'rain_fall_situation.json'
+bucket = 'test-uodu-s3'
+key = '/japan/ishikawa/asanogawa/rain_fall_trend.json'
 
+def lambda_handler(event, context):
     try:
         response = client.get_object(Bucket=bucket, Key=key)
-
         body = response['Body'].read().decode('utf-8')
         result = json.loads(body)
         return result

--- a/getRainFallTrend.py
+++ b/getRainFallTrend.py
@@ -1,0 +1,20 @@
+import json
+import urllib.parse
+import boto3
+
+client = boto3.client('s3')
+
+def lambda_handler(event, context):
+    bucket = 'test-uodu-s3'
+    key = 'rain_fall_situation.json'
+
+    try:
+        response = client.get_object(Bucket=bucket, Key=key)
+
+        body = response['Body'].read().decode('utf-8')
+        result = json.loads(body)
+        return result
+    except Exception as e:
+        print(e)
+        print('Error getting object {} from bucket {}. Make sure they exist and your bucket is in the same region as this function.'.format(key, bucket))
+        raise e

--- a/makeRainFallTrend.py
+++ b/makeRainFallTrend.py
@@ -3,7 +3,7 @@ import time
 import json
 
 bucket = 'test-uodu-s3'
-key = 'rain_fall_situation.json'
+key = '/japan/ishikawa/asanogawa/rain_fall_trend.json'
 
 def lambda_handler(event, context):
     
@@ -31,7 +31,7 @@ def lambda_handler(event, context):
     for row in tmp_dict:
         rain_fall_situation.append(row['Data'][1]['VarCharValue'])
     
-    # 増加量を判定
+    # ToDo:増加量を判定
     print(rain_fall_situation)
     
     # S3へ

--- a/makeRainFallTrend.py
+++ b/makeRainFallTrend.py
@@ -1,0 +1,46 @@
+import boto3
+import time
+import json
+
+bucket = 'test-uodu-s3'
+key = 'rain_fall_situation.json'
+
+def lambda_handler(event, context):
+    
+    s3_client = boto3.client('s3')
+    athena_client = boto3.client('athena', region_name='ap-northeast-1')
+    
+    response = athena_client.start_query_execution(
+        QueryString='SELECT  "現在時刻(分)", "現在値(mm)" FROM rain_fall ORDER BY "現在時刻(月)" DESC, "現在時刻(日)" DESC, "現在時刻(時)" DESC, "現在時刻(分)" DESC LIMIT 10;',
+        QueryExecutionContext={'Database': 'kisyou'},
+        ResultConfiguration={
+            'OutputLocation': "s3://test-uodu-s3/test_athena/athena_results/",
+            'EncryptionConfiguration': {
+                'EncryptionOption': 'SSE_S3'
+            }
+        })
+    
+    time.sleep(50)
+    
+    result = athena_client.get_query_results(
+        QueryExecutionId=response['QueryExecutionId']
+    )
+    
+    rain_fall_situation = []
+    tmp_dict = result['ResultSet']['Rows']
+    for row in tmp_dict:
+        rain_fall_situation.append(row['Data'][1]['VarCharValue'])
+    
+    # 増加量を判定
+    print(rain_fall_situation)
+    
+    # S3へ
+    response = s3_client.put_object(
+        ACL='public-read',
+        Body=b'{"situation":"up","level":0}',
+        #Body=json.dumps(result['ResultSet']['Rows']),
+        Bucket=bucket,
+        Key=key)
+    
+    print(result['ResultSet']['Rows'])
+    return response


### PR DESCRIPTION
## 修正内容
降水量の傾向を取得するAPIを作成します。
レスポンスは現在モックを返しています。

### 概要
1. makeRainFallTrend.pyで直近の降水量の増減データを S3 に JSON で作成する
2. getRainFallTrend.pyで S3 におかれた JSON を取得する

### レスポンス
以下のJsonを返す予定です。
~~
{
  "timestamp": "2017-08-12T12:50:00",
  "observation": "石川県金沢市",
  "trend": "up"
}
~~

timestamp : 傾向を分析した際のタイムスタンプ
observation : 観測地点
trend : 降水量の増減